### PR TITLE
Fixing end of word, adding support for microseconds

### DIFF
--- a/arch/esp8266/bin/flash.sh
+++ b/arch/esp8266/bin/flash.sh
@@ -1,0 +1,10 @@
+#!/bin/sh
+THEPORT=${1:-$ESPPORT}
+if [ -z "$THEPORT" ]
+	then
+		echo "Port definition missing. Either give command-line parameter like '$0 /dev/usb000' or set environment variable ESPPORT"
+		exit 1
+fi
+
+python esptool.py -p $THEPORT write_flash -fs 32m -fm dio -ff 40m 0x00000 rboot.bin 0x1000 blank_config.bin 0x2000 punyforth.bin 0x51000 uber.forth
+

--- a/arch/esp8266/ext.S
+++ b/arch/esp8266/ext.S
@@ -406,3 +406,14 @@ defprimitive "osfreemem",9,osfreemem,REGULAR
     CCALL forth_free_heap
     DPUSH a2                   // free heap size in bytes
     NEXT
+
+defprimitive "time-us",7,timeus,REGULAR
+    CCALL forth_time_us
+    DPUSH a2 // clock time in us
+    NEXT
+
+defprimitive "delay-us",8,delayus,REGULAR
+    DPOP a2                     // us to wait
+    CCALL forth_delay_us
+    NEXT
+

--- a/arch/esp8266/forth/event.forth
+++ b/arch/esp8266/forth/event.forth
@@ -2,6 +2,7 @@ struct
     cell field: .type
     cell field: .time
     cell field: .payload
+    cell field: .time-us
 constant: Event
 
 100 constant: EVT_GPIO

--- a/arch/esp8266/rtos/user/forth_evt.h
+++ b/arch/esp8266/rtos/user/forth_evt.h
@@ -10,6 +10,7 @@ struct forth_event {
     int event_type;
     int event_time;
     int event_payload;
+    unsigned int event_time_us;
 };
 
 void init_event_queue();

--- a/arch/esp8266/rtos/user/forth_gpio.c
+++ b/arch/esp8266/rtos/user/forth_gpio.c
@@ -40,7 +40,8 @@ void __attribute__((weak)) IRAM gpio_interrupt_handler(void) {
             struct forth_event event = {
                 .event_type = EVT_GPIO,
                 .event_time = xTaskGetTickCountFromISR(),
-                .event_payload = gpio_idx
+                .event_payload = gpio_idx,
+                .event_time_us = sdk_system_get_time()
             };
             forth_add_event_isr(&event);
         }

--- a/arch/esp8266/rtos/user/forth_sys.c
+++ b/arch/esp8266/rtos/user/forth_sys.c
@@ -14,3 +14,7 @@ void forth_yield() {
 int forth_free_heap() {
     return (int)xPortGetFreeHeapSize();
 }
+
+unsigned int forth_time_us() {
+    return sdk_system_get_time();
+}

--- a/arch/esp8266/rtos/user/forth_time.c
+++ b/arch/esp8266/rtos/user/forth_time.c
@@ -10,3 +10,12 @@ void forth_delay(int millis) {
     vTaskDelay(millis / portTICK_RATE_MS);    
 }
 
+/**
+ * Delay microseconds
+ *
+ * sdk os_delay_us has only 16bits, so mask them
+ */
+void forth_delay_us(unsigned int microseconds) {
+    sdk_os_delay_us(microseconds & 0x0ffff);
+}
+

--- a/generic/words.S
+++ b/generic/words.S
@@ -378,7 +378,7 @@ word_next_char:
     lbl word_boundary
     .int xt_dup, xt_btick, 13, xt_noteq, xt_branch0
     lbl word_boundary
-    .int xt_dup, xt_btick, 19, xt_noteq, xt_branch0
+    .int xt_dup, xt_btick, 9, xt_noteq, xt_branch0
     lbl word_boundary
     .int xt_branch
     lbl word_next_char


### PR DESCRIPTION
This is my first pull request ever, so any comments are appreciated :)

- commit 43d5759 should be trivial.
- commit b58237e should support linux/mac user. My development environment is a Mac (and ubuntu vm for cross compiling)
- commit bc43d2d is a first step to support microseconds (delay, getting time). I needed microseconds because HC-SR04 (measuring distances) echoes a pulse with a length of microseconds. Ideally the trigger pulse is also 10 microseconds long, although 1ms (1 delay) is ok. Therefore also the addition in the event-handling. Maybe it's better to fill in the field time_us (forth_gpio.c) optionally.

I ran the 'test' module successfully.