### PR TITLE
Fix error in "]" word, when suspending compile mode

### DIFF
--- a/generic/words.S
+++ b/generic/words.S
@@ -429,7 +429,7 @@ undefword:
     .int xt_branch
     lbl compile
 suspend_compile:
-    .int xt_nip, xt_nip
+    .int xt_drop2
     .int xt_btick, STATE_INTERPRET, xt_btick, state_var, xt_store
     .int xt_end_word
 


### PR DESCRIPTION
https://github.com/zeroflag/punyforth/blob/32a30163e3defaf231a286bcb56a430b8078996a/generic/words.S#L432

The referenced line causes trying to compile this word to crash punyforth (esp8266).:

`: test:[ 1 if [ 60 5 + ] literal then ;`